### PR TITLE
Bind port on arbitrary ip addresses

### DIFF
--- a/proxy2.py
+++ b/proxy2.py
@@ -372,7 +372,8 @@ def test(HandlerClass=ProxyRequestHandler, ServerClass=ThreadingHTTPServer, prot
         port = int(sys.argv[1])
     else:
         port = 8080
-    server_address = ('::1', port)
+    # server_address = ('::1', port)
+    server_address = ('0.0.0.0', port)
 
     HandlerClass.protocol_version = protocol
     httpd = ServerClass(server_address, HandlerClass)


### PR DESCRIPTION
I've added `server_address = ('0.0.0.0', port)` to attempt to open the proxy to non-localhost ip's.

However, no matter which ip address I attempt (aside from `::1`), I get this error.

Is it possible to bind to a different IP address?

```
Traceback (most recent call last):
  File "proxy2.py", line 387, in <module>
    test()
  File "proxy2.py", line 379, in test
    httpd = ServerClass(server_address, HandlerClass)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 417, in __init__
    self.server_bind()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 431, in server_bind
    self.socket.bind(self.server_address)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 49] Can't assign requested address
```