### PR TITLE
Handle non-unicode chars in url

### DIFF
--- a/proxy2.py
+++ b/proxy2.py
@@ -288,7 +288,10 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
 
     def print_info(self, req, req_body, res, res_body):
         def parse_qsl(s):
-            return '\n'.join("{:<20} {}".format(k, v) for k, v in urlparse.parse_qsl(s, keep_blank_values=True))
+            if type(s) == bytes:
+                return '\n'.join("{:<20} {}".format(k, v) for k, v in urlparse.parse_qsl(s, keep_blank_values=True))
+            else:
+                return '\n'.join("{:<20} {}".format(k, v) for k, v in urlparse.parse_qsl(s.decode("utf-8"), keep_blank_values=True))
 
         req_header_text = "{} {} {}\n{}".format(req.command, req.path, req.request_version, req.headers)
         res_header_text = "{} {} {}\n{}".format(res.response_version, res.status, res.reason, res.headers)


### PR DESCRIPTION
If a url has a non-unicode path, then the proxy crashes with:

```
Exception happened during processing of request from ('::ffff:127.0.0.1', 34814, 0, 0)
Traceback (most recent call last):
  File "/usr/lib/python3.6/socketserver.py", line 639, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "./proxy2.py", line 63, in __init__
    BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
  File "/usr/lib/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "/usr/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/usr/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "./proxy2.py", line 210, in do_GET
    self.save_handler(req, req_body, res, res_body_plain)
  File "./proxy2.py", line 379, in save_handler
    self.print_info(req, req_body, res, res_body)
  File "./proxy2.py", line 318, in print_info
    req_body_text = parse_qsl(req_body)
  File "./proxy2.py", line 291, in parse_qsl
    return '\n'.join("{:<20} {}".format(k, v) for k, v in urlparse.parse_qsl(s, keep_blank_values=True))
  File "/usr/lib/python3.6/urllib/parse.py", line 703, in parse_qsl
    value = _coerce_result(value)
  File "/usr/lib/python3.6/urllib/parse.py", line 103, in _encode_result
    return obj.encode(encoding, errors)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 13-32: ordinal not in range(128)

```

I found that sometimes the information in parse is a string, and sometimes its bytes, this solves the problem.