### PR TITLE
add subjectAltName for valid certification in recent browser

### DIFF
--- a/proxy2.py
+++ b/proxy2.py
@@ -86,7 +86,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     fp.write(self.conf_template.substitute(category = cert_category, hostname = hostname))
                 epoch = "%d" % (time.time() * 1000)
                 p1 = Popen(["openssl", "req", "-new", "-key", self.certkey, "-subj", "/CN=%s" % hostname], stdout=PIPE)
-                p2 = Popen(["openssl", "x509", "-req", "-extfile", confpath, "-days", "3650", "-CA", self.cacert, "-CAkey", self.cakey, "-set_serial", epoch, "-out", certpath], stdin=p1.stdout, stderr=PIPE)
+                p2 = Popen(["openssl", "x509", "-req", "-extfile", confpath, "-days", "3650", "-CA", self.cacert, "-CAkey", self.cakey, "-set_serial", epoch, "-sha512", "-out", certpath], stdin=p1.stdout, stderr=PIPE)
                 p2.communicate()
                 os.unlink(confpath)
 

--- a/setup_https_intercept.sh
+++ b/setup_https_intercept.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 openssl genrsa -out ca.key 2048
-openssl req -new -x509 -days 3650 -key ca.key -out ca.crt -subj "/CN=proxy2 CA"
+openssl req -new -x509 -days 3650 -key ca.key -sha512 -out ca.crt -subj "/CN=proxy2 CA"
 openssl genrsa -out cert.key 2048
 mkdir certs/


### PR DESCRIPTION
from the recent browser, certificate with CN(Common Name) is not enough to verify. [Chrome](https://support.google.com/chrome/a/answer/7391219) requires subjectAlternativeName for version 65 and later, so I added subjectAltName in certificate.